### PR TITLE
fix: slow performance due to recursive FutureBuilder call

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -151,6 +151,7 @@ class _FileManagerApp extends State<FileManagerApp> {
           builder: (context) =>
             LibraryView(
               currentDirectory: widget.directory ?? (LibraryEntry.getDefaultEntry(context) == null ? io.Directory.current : LibraryEntry.getDefaultEntry(context)!.entry),
+              parentContext: context,
             ),
         ),
       ),

--- a/lib/views/library.dart
+++ b/lib/views/library.dart
@@ -89,7 +89,7 @@ class _LibraryViewState extends State<LibraryView> with FileManagerLogic<Library
         MaterialPageRoute(
           builder: (context) => LibraryView(
             currentDirectory: entry,
-	    parentContext: context,
+            parentContext: context,
           ),
           settings: RouteSettings(
             name: 'LibraryView',
@@ -190,7 +190,7 @@ class _LibraryViewState extends State<LibraryView> with FileManagerLogic<Library
         MaterialPageRoute(
           builder: (context) => LibraryView(
             currentDirectory: entry,
-	    parentContext: context,
+            parentContext: context,
           ),
           settings: RouteSettings(
             name: 'LibraryView',

--- a/lib/views/library.dart
+++ b/lib/views/library.dart
@@ -18,9 +18,11 @@ class LibraryView extends StatefulWidget {
   const LibraryView({
     super.key,
     this.currentDirectory,
+    required this.parentContext,
   });
 
   final io.Directory? currentDirectory;
+  final BuildContext parentContext;
 
   @override
   State<LibraryView> createState() => _LibraryViewState();
@@ -34,10 +36,13 @@ class _LibraryViewState extends State<LibraryView> with FileManagerLogic<Library
   List<ClipboardEntry> clipboard = <ClipboardEntry>[];
   bool runningClipboard = false;
   bool isFavorite = false;
+  late final Future<void> populateLibraryEntriesFuture;
 
   @override
   void initState() {
     super.initState();
+
+    populateLibraryEntriesFuture = populateLibraryEntries(widget.parentContext);
 
     currentDirectory = widget.currentDirectory;
 
@@ -84,6 +89,7 @@ class _LibraryViewState extends State<LibraryView> with FileManagerLogic<Library
         MaterialPageRoute(
           builder: (context) => LibraryView(
             currentDirectory: entry,
+	    parentContext: context,
           ),
           settings: RouteSettings(
             name: 'LibraryView',
@@ -184,6 +190,7 @@ class _LibraryViewState extends State<LibraryView> with FileManagerLogic<Library
         MaterialPageRoute(
           builder: (context) => LibraryView(
             currentDirectory: entry,
+	    parentContext: context,
           ),
           settings: RouteSettings(
             name: 'LibraryView',
@@ -213,7 +220,7 @@ class _LibraryViewState extends State<LibraryView> with FileManagerLogic<Library
       ),
     ];
     return FutureBuilder(
-        future: populateLibraryEntries(context),
+        future: populateLibraryEntriesFuture,
         builder: (context, snapshot) =>
             Consumer<Clipboard>(
               builder: (context, clipboard, widget) =>

--- a/lib/widgets/library_entry.dart
+++ b/lib/widgets/library_entry.dart
@@ -42,7 +42,7 @@ class LibraryEntry extends StatelessWidget {
           MaterialPageRoute(
             builder: (context) => LibraryView(
               currentDirectory: entry,
-	      parentContext: context,
+              parentContext: context,
             ),
             settings: RouteSettings(
               name: 'LibraryView',

--- a/lib/widgets/library_entry.dart
+++ b/lib/widgets/library_entry.dart
@@ -42,6 +42,7 @@ class LibraryEntry extends StatelessWidget {
           MaterialPageRoute(
             builder: (context) => LibraryView(
               currentDirectory: entry,
+	      parentContext: context,
             ),
             settings: RouteSettings(
               name: 'LibraryView',


### PR DESCRIPTION
A future was created inside `FutureBuilder`, this caused the future to be called each time the widget is rebuild. Which for some reason, happened every seconds in this app. This caused a massive slow down and janks.

This PR is a temporary fix by passing the `BuildContext` from parent Widget builder used for localize strings. There is still a room for improvement to improve this way of handling localization.